### PR TITLE
feat: modify default retry policy to no retry

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
+++ b/pilot/pkg/networking/core/v1alpha3/route/retry/retry.go
@@ -32,20 +32,10 @@ var (
 )
 
 // DefaultPolicy gets a copy of the default retry policy.
+// default set NumRetries to 0 by jst
 func DefaultPolicy() *route.RetryPolicy {
 	policy := route.RetryPolicy{
-		NumRetries:           &wrappers.UInt32Value{Value: 2},
-		RetryOn:              "connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes",
-		RetriableStatusCodes: []uint32{http.StatusServiceUnavailable},
-		RetryHostPredicate: []*route.RetryPolicy_RetryHostPredicate{
-			{
-				// to configure retries to prefer hosts that haven’t been attempted already,
-				// the builtin `envoy.retry_host_predicates.previous_hosts` predicate can be used.
-				Name: "envoy.retry_host_predicates.previous_hosts",
-			},
-		},
-		// TODO: allow this to be configured via API.
-		HostSelectionRetryMaxAttempts: 5,
+		NumRetries:           &wrappers.UInt32Value{Value: 0},
 	}
 	return &policy
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

istio retry policy default to set NumRetries = 2, but not all the service allow to retry. so we change the default policy to no retry. if a service want to set retry policy, they can do in the DestinationRule.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure


Pull Request Attributes

Please check any characteristics that apply to this pull request. 

[ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
