### PR TITLE
fix(secretcontroller): 实现 make-before-break 避免配置丢失

### DIFF
--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -84,6 +84,19 @@ func (c *Controller) DeleteRegistry(clusterID string, providerID serviceregistry
 	log.Infof("Registry for the cluster %s has been deleted.", clusterID)
 }
 
+func (c *Controller) UpdateRegistry(clusterID string, providerID serviceregistry.ProviderID, newRegistry serviceregistry.Instance) {
+	c.storeLock.Lock()
+	defer c.storeLock.Unlock()
+
+	if index, ok := c.getRegistryIndex(clusterID, providerID); ok {
+		c.registries[index] = newRegistry
+		log.Infof("Registry for the cluster %s has been updated.", clusterID)
+	} else {
+		c.registries = append(c.registries, newRegistry)
+		log.Infof("Registry for the cluster %s was not found, adding as new.", clusterID)
+	}
+}
+
 // GetRegistries returns a copy of all registries
 func (c *Controller) GetRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()
@@ -304,10 +317,10 @@ func (c *Controller) AppendWorkloadHandler(f func(*model.WorkloadInstance, model
 // To retain such trust domain expansion behavior, the xDS server implementation should wrap any (even if single)
 // service registry by this aggreated one.
 // For example,
-// - { "spiffe://cluster.local/bar@iam.gserviceaccount.com"}; when annotation is used on corresponding workloads.
-// - { "spiffe://cluster.local/ns/default/sa/foo" }; normal kubernetes cases
-// - { "spiffe://cluster.local/ns/default/sa/foo", "spiffe://trust-domain-alias/ns/default/sa/foo" };
-//   if the trust domain alias is configured.
+//   - { "spiffe://cluster.local/bar@iam.gserviceaccount.com"}; when annotation is used on corresponding workloads.
+//   - { "spiffe://cluster.local/ns/default/sa/foo" }; normal kubernetes cases
+//   - { "spiffe://cluster.local/ns/default/sa/foo", "spiffe://trust-domain-alias/ns/default/sa/foo" };
+//     if the trust domain alias is configured.
 func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
 	out := map[string]struct{}{}
 	for _, r := range c.GetRegistries() {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -315,10 +315,65 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 }
 
 func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
-	if err := m.DeleteMemberCluster(clusterID); err != nil {
-		return err
+	m.m.Lock()
+
+	if m.closing {
+		m.m.Unlock()
+		return fmt.Errorf("failed updating member cluster %s: server shutting down", clusterID)
 	}
-	return m.AddMemberCluster(clusterID, rc)
+
+	oldKc, exists := m.remoteKubeControllers[clusterID]
+	if !exists {
+		m.m.Unlock()
+		return m.AddMemberCluster(clusterID, rc)
+	}
+
+	client := rc.Client
+	clusterStopCh := rc.Stop
+
+	options := m.opts
+	options.ClusterID = clusterID
+	options.SyncTimeout = rc.SyncTimeout
+
+	log.Infof("Updating Kubernetes service registry %q (make-before-break)", options.ClusterID)
+	newKubeRegistry := NewController(client, options)
+
+	// Phase 1 (make): atomically replace the registry in the aggregate controller
+	m.serviceController.UpdateRegistry(clusterID, serviceregistry.Kubernetes, newKubeRegistry)
+	m.remoteKubeControllers[clusterID] = &kubeController{
+		Controller: newKubeRegistry,
+	}
+
+	m.m.Unlock()
+
+	newKubeRegistry.AppendServiceHandler(func(svc *model.Service, ev model.Event) { m.updateHandler(svc) })
+
+	if m.serviceEntryStore != nil && features.EnableServiceEntrySelectPods {
+		newKubeRegistry.AppendWorkloadHandler(m.serviceEntryStore.WorkloadInstanceHandler)
+	}
+
+	// TODO: update path 暂不处理 leader election、webhook cert patching、service export controller，
+	// 这些由 feature flag 控制的次要功能不会导致配置丢失的灾难性 bug。
+
+	if m.serviceController.Running() {
+		go newKubeRegistry.Run(clusterStopCh)
+	}
+
+	// Phase 3 (break): 等待新集群同步完成后，再清理旧集群
+	go func() {
+		<-rc.SyncedCh
+		if err := oldKc.Cleanup(); err != nil {
+			log.Warnf("failed cleaning up old services in %s: %v", clusterID, err)
+		}
+		if oldKc.workloadEntryStore != nil {
+			m.serviceController.DeleteRegistry(clusterID, serviceregistry.External)
+		}
+		if m.XDSUpdater != nil {
+			m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})
+		}
+	}()
+
+	return nil
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -92,15 +92,27 @@ type Cluster struct {
 	// Stop channel which is closed when the cluster is removed or the secretcontroller that created the client is stopped.
 	// Client.RunAndWait is called using this channel.
 	Stop chan struct{}
+	// SyncedCh is closed when the cluster's initial sync (Run) completes or exits.
+	// Used by make-before-break logic to wait for the new cluster to be ready before cleaning up the old one.
+	SyncedCh chan struct{}
 	// initialSync is marked when RunAndWait completes
 	initialSync *atomic.Bool
 	// SyncTimeout is marked after features.RemoteClusterTimeout
 	SyncTimeout *atomic.Bool
+
+	syncedOnce sync.Once
+}
+
+func (r *Cluster) closeSyncedCh() {
+	r.syncedOnce.Do(func() {
+		close(r.SyncedCh)
+	})
 }
 
 // Run starts the cluster's informers and waits for caches to sync. Once caches are synced, we mark the cluster synced.
 // This should be called after each of the handlers have registered informers, and should be run in a goroutine.
 func (r *Cluster) Run() {
+	defer r.closeSyncedCh()
 	r.Client.RunAndWait(r.Stop)
 	r.initialSync.Store(true)
 }
@@ -146,6 +158,32 @@ func (c *ClusterStore) Len() int {
 	c.Lock()
 	defer c.Unlock()
 	return len(c.remoteClusters)
+}
+
+// Swap atomically replaces the cluster entry and returns a PendingClusterSwap
+// to manage the lifecycle of the old cluster.
+func (c *ClusterStore) Swap(key string, value *Cluster) *PendingClusterSwap {
+	c.Lock()
+	defer c.Unlock()
+	old := c.remoteClusters[key]
+	c.remoteClusters[key] = value
+	return &PendingClusterSwap{Old: old, New: value}
+}
+
+// PendingClusterSwap tracks an in-progress cluster replacement for make-before-break.
+// Call Complete() to close the old cluster's Stop channel after the new cluster is ready.
+type PendingClusterSwap struct {
+	Old  *Cluster
+	New  *Cluster
+	once sync.Once
+}
+
+func (s *PendingClusterSwap) Complete() {
+	s.once.Do(func() {
+		if s.Old != nil {
+			close(s.Old.Stop)
+		}
+	})
 }
 
 // NewController returns a new secret controller
@@ -373,7 +411,8 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, secretName string) (
 		secretName: secretName,
 		Client:     clients,
 		// access outside this package should only be reading
-		Stop: make(chan struct{}),
+		Stop:     make(chan struct{}),
+		SyncedCh: make(chan struct{}),
 		// for use inside the package, to close on cleanup
 		initialSync:   atomic.NewBool(false),
 		SyncTimeout:   &c.remoteSyncTimeout,
@@ -384,8 +423,10 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, secretName string) (
 func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 	for clusterID, kubeConfig := range s.Data {
 		action, callback := "Adding", c.addCallback
+		isUpdate := false
 		if prev, ok := c.cs.Get(clusterID); ok {
 			action, callback = "Updating", c.updateCallback
+			isUpdate = true
 			// clusterID must be unique even across multiple secrets
 			if prev.secretName != secretName {
 				log.Errorf("ClusterID reused in two different secrets: %v and %v. ClusterID "+
@@ -405,12 +446,27 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			log.Errorf("%s cluster_id=%v from secret=%v: %v", action, clusterID, secretName, err)
 			continue
 		}
-		c.cs.Store(clusterID, remoteCluster)
-		if err := callback(clusterID, remoteCluster); err != nil {
-			log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
-			continue
+
+		if isUpdate {
+			swap := c.cs.Swap(clusterID, remoteCluster)
+			if err := callback(clusterID, remoteCluster); err != nil {
+				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
+				c.cs.Store(clusterID, swap.Old)
+				close(remoteCluster.Stop)
+				continue
+			}
+			go func() {
+				remoteCluster.Run()
+				swap.Complete()
+			}()
+		} else {
+			c.cs.Store(clusterID, remoteCluster)
+			if err := callback(clusterID, remoteCluster); err != nil {
+				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
+				continue
+			}
+			go remoteCluster.Run()
 		}
-		go remoteCluster.Run()
 	}
 
 	log.Infof("Number of remote clusters: %d", c.cs.Len())


### PR DESCRIPTION
将 UpdateMemberCluster 从 delete-then-add 改为 make-before-break 模式， 防止 Secret 更新异常时整个集群配置被删除的灾难性 bug。

核心变更：
- Cluster 新增 SyncedCh 用于同步信号
- 新增 PendingClusterSwap 管理新旧集群生命周期
- aggregate.Controller 新增 UpdateRegistry 方法
- UpdateMemberCluster 重写为三段式：make→sync→break

AI-Co-Authored-By: Claude

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
