### PR TITLE
feat: remote cluster Secret 更新采用 Make-Before-Break 策略避免流量中断

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -115,4 +115,4 @@ require (
 replace github.com/envoyproxy/go-control-plane => github.com/istio-mt/go-control-plane v0.9.9-0.20220510090233-9a835672a6b3
 
 // add mt_ext_proc proto config, branch mt-1.10.6
-replace istio.io/api => gitlab.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91
+replace istio.io/api => git.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBr
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
+git.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91 h1:m4xcEf7D6pl9YAuo7CNCx9VgjsJNG7xk/QIIgoKasnI=
+git.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -976,8 +978,6 @@ github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 github.com/ziutek/mymysql v1.5.4/go.mod h1:LMSpPZ6DbqWFxNCHW77HeMg9I646SAhApZ/wKdgO/C0=
-gitlab.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91 h1:PRmIcWW0MXJlf/z1dMSVmNdMYWbeGJMIdozsdQvAme8=
-gitlab.meitu.com/istio-mt/api v0.0.0-20230925015357-581df05d8a91/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/pilot/pkg/secrets/kube/multicluster.go
+++ b/pilot/pkg/secrets/kube/multicluster.go
@@ -68,8 +68,11 @@ func (m *Multicluster) addMemberCluster(clients kube.Client, key string) {
 }
 
 func (m *Multicluster) updateMemberCluster(clients kube.Client, key string) {
-	m.deleteMemberCluster(key)
-	m.addMemberCluster(clients, key)
+	log.Infof("updating Kubernetes credential reader for cluster %v", key)
+	sc := NewSecretsController(clients, key)
+	m.m.Lock()
+	m.remoteKubeControllers[key] = sc // Directly replace, no need to delete first
+	m.m.Unlock()
 }
 
 func (m *Multicluster) deleteMemberCluster(key string) {

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -84,6 +84,29 @@ func (c *Controller) DeleteRegistry(clusterID string, providerID serviceregistry
 	log.Infof("Registry for the cluster %s has been deleted.", clusterID)
 }
 
+// ReplaceRegistry atomically replaces an existing registry with a new one.
+// If no existing registry is found, the new registry is appended.
+// Returns the old registry if replaced, nil otherwise.
+func (c *Controller) ReplaceRegistry(newRegistry serviceregistry.Instance) serviceregistry.Instance {
+	c.storeLock.Lock()
+	defer c.storeLock.Unlock()
+
+	clusterID := newRegistry.Cluster()
+	providerID := newRegistry.Provider()
+
+	if index, ok := c.getRegistryIndex(clusterID, providerID); ok {
+		old := c.registries[index]
+		c.registries[index] = newRegistry
+		log.Infof("Registry for cluster %s has been replaced.", clusterID)
+		return old
+	}
+
+	// 如果旧 registry 不存在，当作 add 处理
+	c.registries = append(c.registries, newRegistry)
+	log.Infof("Registry for cluster %s has been added (no previous registry found).", clusterID)
+	return nil
+}
+
 // GetRegistries returns a copy of all registries
 func (c *Controller) GetRegistries() []serviceregistry.Instance {
 	c.storeLock.RLock()

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -86,8 +86,7 @@ func (c *Controller) DeleteRegistry(clusterID string, providerID serviceregistry
 
 // ReplaceRegistry atomically replaces an existing registry with a new one.
 // If no existing registry is found, the new registry is appended.
-// Returns the old registry if replaced, nil otherwise.
-func (c *Controller) ReplaceRegistry(newRegistry serviceregistry.Instance) serviceregistry.Instance {
+func (c *Controller) ReplaceRegistry(newRegistry serviceregistry.Instance) {
 	c.storeLock.Lock()
 	defer c.storeLock.Unlock()
 
@@ -95,16 +94,13 @@ func (c *Controller) ReplaceRegistry(newRegistry serviceregistry.Instance) servi
 	providerID := newRegistry.Provider()
 
 	if index, ok := c.getRegistryIndex(clusterID, providerID); ok {
-		old := c.registries[index]
 		c.registries[index] = newRegistry
 		log.Infof("Registry for cluster %s has been replaced.", clusterID)
-		return old
+		return
 	}
-
 	// 如果旧 registry 不存在，当作 add 处理
 	c.registries = append(c.registries, newRegistry)
 	log.Infof("Registry for cluster %s has been added (no previous registry found).", clusterID)
-	return nil
 }
 
 // GetRegistries returns a copy of all registries
@@ -327,10 +323,10 @@ func (c *Controller) AppendWorkloadHandler(f func(*model.WorkloadInstance, model
 // To retain such trust domain expansion behavior, the xDS server implementation should wrap any (even if single)
 // service registry by this aggreated one.
 // For example,
-// - { "spiffe://cluster.local/bar@iam.gserviceaccount.com"}; when annotation is used on corresponding workloads.
-// - { "spiffe://cluster.local/ns/default/sa/foo" }; normal kubernetes cases
-// - { "spiffe://cluster.local/ns/default/sa/foo", "spiffe://trust-domain-alias/ns/default/sa/foo" };
-//   if the trust domain alias is configured.
+//   - { "spiffe://cluster.local/bar@iam.gserviceaccount.com"}; when annotation is used on corresponding workloads.
+//   - { "spiffe://cluster.local/ns/default/sa/foo" }; normal kubernetes cases
+//   - { "spiffe://cluster.local/ns/default/sa/foo", "spiffe://trust-domain-alias/ns/default/sa/foo" };
+//     if the trust domain alias is configured.
 func (c *Controller) GetIstioServiceAccounts(svc *model.Service, ports []int) []string {
 	out := map[string]struct{}{}
 	for _, r := range c.GetRegistries() {

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -180,6 +180,13 @@ func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontrolle
 // For add: registers a new registry in the aggregate controller.
 // For update (Make-Before-Break): atomically replaces the old registry, then cleans up old resources.
 func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
+	m.m.Lock()
+	defer m.m.Unlock()
+
+	if m.closing {
+		return fmt.Errorf("failed addOrUpdateMemberCluster %s: server shutting down", clusterID)
+	}
+
 	client := rc.Client
 	clusterStopCh := rc.Stop
 
@@ -191,40 +198,16 @@ func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcont
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
-
 	newKc := &kubeController{
 		Controller: kubeRegistry,
 	}
 	// localCluster may also be the "config" cluster, in an external-istiod setup.
 	localCluster := m.opts.ClusterID == clusterID
-
-	// ========== Register/Replace in aggregate controller (inside lock) ==========
-	m.m.Lock()
-
-	if m.closing {
-		m.m.Unlock()
-		return fmt.Errorf("failed adding member cluster %s: server shutting down", clusterID)
-	}
-
 	// Check if this is an update (old controller exists)
 	oldKc, isUpdate := m.remoteKubeControllers[clusterID]
-
-	if isUpdate {
-		// Atomically replace in aggregate controller to avoid any gap
-		m.serviceController.ReplaceRegistry(kubeRegistry)
-	} else {
-		m.serviceController.AddRegistry(kubeRegistry)
-	}
-
-	m.remoteKubeControllers[clusterID] = newKc
-
-	m.m.Unlock()
-
-	// ========== Register handlers (outside lock) ==========
 	// Only need to add service handler for kubernetes registry as `initRegistryEventHandlers`,
 	// because when endpoints update `XDSUpdater.EDSUpdate` has already been called.
 	kubeRegistry.AppendServiceHandler(func(svc *model.Service, ev model.Event) { m.updateHandler(svc) })
-
 	// TODO move instance cache out of registries
 	if m.serviceEntryStore != nil && features.EnableServiceEntrySelectPods {
 		// Add an instance handler in the kubernetes registry to notify service entry store about pod events
@@ -243,11 +226,6 @@ func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcont
 					configStore, model.MakeIstioStore(configStore), options.XDSUpdater,
 					serviceentry.DisableServiceEntryProcessing(), serviceentry.WithClusterID(clusterID))
 				newKc.workloadEntryStore = workloadEntryStore
-				if isUpdate && oldKc.workloadEntryStore != nil {
-					m.serviceController.ReplaceRegistry(workloadEntryStore)
-				} else {
-					m.serviceController.AddRegistry(workloadEntryStore)
-				}
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
 				workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
 				go configStore.Run(clusterStopCh)
@@ -341,6 +319,14 @@ func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcont
 		})
 	}
 
+	// Atomically replace in aggregate controller to avoid any gap
+	m.serviceController.ReplaceRegistry(kubeRegistry)
+	m.remoteKubeControllers[clusterID] = newKc
+	if newKc.workloadEntryStore != nil {
+		// TODO workloadEntryStore Cluster() 返回空字符串，因此 workloadEntryStore 只会存在一个实例，而且无法删除，因为指定的 clusterID 并非空字符串
+		m.serviceController.ReplaceRegistry(newKc.workloadEntryStore)
+	}
+
 	// ========== Clean up old controller if this is an update ==========
 	if isUpdate {
 		if err := oldKc.Cleanup(); err != nil {
@@ -348,6 +334,7 @@ func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcont
 		}
 		if oldKc.workloadEntryStore != nil && newKc.workloadEntryStore == nil {
 			// Old had workloadEntryStore but new doesn't — remove it from aggregate
+			// TODO workloadEntryStore Cluster() 返回空字符串，无法删除，因为指定的 clusterID 并非空字符串
 			m.serviceController.DeleteRegistry(clusterID, serviceregistry.External)
 		}
 		// Trigger a full config update to ensure XDS pushes the latest state

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -169,13 +169,17 @@ func (m *Multicluster) close() (err error) {
 // when a remote cluster is added.  This function needs to set up all the handlers
 // to watch for resources being added, deleted or changed on remote clusters.
 func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
-	m.m.Lock()
+	return m.addOrUpdateMemberCluster(clusterID, rc)
+}
 
-	if m.closing {
-		m.m.Unlock()
-		return fmt.Errorf("failed adding member cluster %s: server shutting down", clusterID)
-	}
+func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
+	return m.addOrUpdateMemberCluster(clusterID, rc)
+}
 
+// addOrUpdateMemberCluster handles both add and update scenarios for a member cluster.
+// For add: registers a new registry in the aggregate controller.
+// For update (Make-Before-Break): atomically replaces the old registry, then cleans up old resources.
+func (m *Multicluster) addOrUpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
 	client := rc.Client
 	clusterStopCh := rc.Stop
 
@@ -187,15 +191,36 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 
 	log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 	kubeRegistry := NewController(client, options)
-	m.serviceController.AddRegistry(kubeRegistry)
-	m.remoteKubeControllers[clusterID] = &kubeController{
+
+	newKc := &kubeController{
 		Controller: kubeRegistry,
 	}
 	// localCluster may also be the "config" cluster, in an external-istiod setup.
 	localCluster := m.opts.ClusterID == clusterID
 
+	// ========== Register/Replace in aggregate controller (inside lock) ==========
+	m.m.Lock()
+
+	if m.closing {
+		m.m.Unlock()
+		return fmt.Errorf("failed adding member cluster %s: server shutting down", clusterID)
+	}
+
+	// Check if this is an update (old controller exists)
+	oldKc, isUpdate := m.remoteKubeControllers[clusterID]
+
+	if isUpdate {
+		// Atomically replace in aggregate controller to avoid any gap
+		m.serviceController.ReplaceRegistry(kubeRegistry)
+	} else {
+		m.serviceController.AddRegistry(kubeRegistry)
+	}
+
+	m.remoteKubeControllers[clusterID] = newKc
+
 	m.m.Unlock()
 
+	// ========== Register handlers (outside lock) ==========
 	// Only need to add service handler for kubernetes registry as `initRegistryEventHandlers`,
 	// because when endpoints update `XDSUpdater.EDSUpdate` has already been called.
 	kubeRegistry.AppendServiceHandler(func(svc *model.Service, ev model.Event) { m.updateHandler(svc) })
@@ -214,12 +239,17 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 		} else if features.WorkloadEntryCrossCluster {
 			// TODO only do this for non-remotes, can't guarantee CRDs in remotes (depends on https://github.com/istio/istio/pull/29824)
 			if configStore, err := createConfigStore(client, m.revision, options); err == nil {
-				m.remoteKubeControllers[clusterID].workloadEntryStore = serviceentry.NewServiceDiscovery(
+				workloadEntryStore := serviceentry.NewServiceDiscovery(
 					configStore, model.MakeIstioStore(configStore), options.XDSUpdater,
 					serviceentry.DisableServiceEntryProcessing(), serviceentry.WithClusterID(clusterID))
-				m.serviceController.AddRegistry(m.remoteKubeControllers[clusterID].workloadEntryStore)
+				newKc.workloadEntryStore = workloadEntryStore
+				if isUpdate && oldKc.workloadEntryStore != nil {
+					m.serviceController.ReplaceRegistry(workloadEntryStore)
+				} else {
+					m.serviceController.AddRegistry(workloadEntryStore)
+				}
 				// Services can select WorkloadEntry from the same cluster. We only duplicate the Service to configure kube-dns.
-				m.remoteKubeControllers[clusterID].workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
+				workloadEntryStore.AppendWorkloadHandler(kubeRegistry.WorkloadInstanceHandler)
 				go configStore.Run(clusterStopCh)
 			} else {
 				return fmt.Errorf("failed creating config configStore for cluster %s: %v", clusterID, err)
@@ -311,14 +341,22 @@ func (m *Multicluster) AddMemberCluster(clusterID string, rc *secretcontroller.C
 		})
 	}
 
-	return nil
-}
-
-func (m *Multicluster) UpdateMemberCluster(clusterID string, rc *secretcontroller.Cluster) error {
-	if err := m.DeleteMemberCluster(clusterID); err != nil {
-		return err
+	// ========== Clean up old controller if this is an update ==========
+	if isUpdate {
+		if err := oldKc.Cleanup(); err != nil {
+			log.Warnf("failed cleaning up old services in %s: %v", clusterID, err)
+		}
+		if oldKc.workloadEntryStore != nil && newKc.workloadEntryStore == nil {
+			// Old had workloadEntryStore but new doesn't — remove it from aggregate
+			m.serviceController.DeleteRegistry(clusterID, serviceregistry.External)
+		}
+		// Trigger a full config update to ensure XDS pushes the latest state
+		if m.XDSUpdater != nil {
+			m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true})
+		}
 	}
-	return m.AddMemberCluster(clusterID, rc)
+
+	return nil
 }
 
 // DeleteMemberCluster is passed to the secret controller as a callback to be called

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -369,6 +369,14 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, secretName string) (
 	if err != nil {
 		return nil, err
 	}
+
+	// Probe the API server to verify connectivity and certificate validity before proceeding.
+	// This is a lightweight call that validates TLS handshake and authentication configuration,
+	// failing fast instead of waiting for Informer sync to surface connection issues.
+	if _, err := clients.Kube().Discovery().ServerVersion(); err != nil {
+		return nil, fmt.Errorf("failed to connect to API server for secret %s: %v", secretName, err)
+	}
+
 	return &Cluster{
 		secretName: secretName,
 		Client:     clients,
@@ -384,6 +392,7 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, secretName string) (
 func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 	for clusterID, kubeConfig := range s.Data {
 		action, callback := "Adding", c.addCallback
+		var oldCluster *Cluster
 		if prev, ok := c.cs.Get(clusterID); ok {
 			action, callback = "Updating", c.updateCallback
 			// clusterID must be unique even across multiple secrets
@@ -397,6 +406,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 				log.Infof("%s cluster_id=%v from secret=%v: (kubeconfig are identical)", clusterID, secretName)
 				continue
 			}
+			oldCluster = prev
 		}
 		log.Infof("%s cluster %v from secret %v", action, clusterID, secretName)
 
@@ -405,12 +415,71 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			log.Errorf("%s cluster_id=%v from secret=%v: %v", action, clusterID, secretName, err)
 			continue
 		}
-		c.cs.Store(clusterID, remoteCluster)
-		if err := callback(clusterID, remoteCluster); err != nil {
-			log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
-			continue
+
+		if oldCluster != nil {
+			// ===== Update scenario: Make-Before-Break =====
+			// Phase 1: Start the new cluster's Informer sync first
+			go remoteCluster.Run()
+
+			// Phase 2: Wait for the new cluster to sync with a hard timeout.
+			// We use an independent timeout (1 minute) instead of relying on the global remoteSyncTimeout,
+			// because the global timeout is shared across all clusters and may have already fired,
+			// causing HasSynced() to return true immediately without actual sync completion.
+			log.Infof("Waiting for new cluster %v to sync before replacing old cluster", clusterID)
+
+			// Guard: ensure syncInterval has a reasonable value to avoid hot-polling
+			interval := c.syncInterval
+			if interval <= 0 {
+				interval = 100 * time.Millisecond
+			}
+
+			const updateSyncTimeout = 1 * time.Minute
+			timeoutCh := make(chan struct{})
+			timeoutTimer := time.AfterFunc(updateSyncTimeout, func() {
+				close(timeoutCh)
+			})
+
+			// Wait until either: initialSync completes, timeout fires, or remoteCluster.Stop is closed
+			synced := false
+			syncDone := make(chan bool, 1)
+			go func() {
+				syncDone <- kube.WaitForCacheSyncInterval(remoteCluster.Stop, interval, remoteCluster.initialSync.Load)
+			}()
+
+			select {
+			case synced = <-syncDone:
+				timeoutTimer.Stop()
+			case <-timeoutCh:
+				// Timeout fired — stop waiting
+			}
+
+			if !synced {
+				log.Errorf("New cluster %v failed to sync within %v, skipping update", clusterID, updateSyncTimeout)
+				close(remoteCluster.Stop) // Clean up new cluster resources to prevent goroutine leak
+				continue
+			}
+			log.Infof("New cluster %v synced, proceeding with replacement", clusterID)
+
+			// Phase 3: Execute callback first, then update ClusterStore (state consistency)
+			if err := callback(clusterID, remoteCluster); err != nil {
+				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
+				close(remoteCluster.Stop) // Callback failed, clean up new cluster resources
+				continue
+			}
+			c.cs.Store(clusterID, remoteCluster)
+
+			// Phase 4: Close old cluster resources
+			log.Infof("Closing old cluster client for cluster_id=%v", clusterID)
+			close(oldCluster.Stop)
+		} else {
+			// ===== Add scenario: keep original logic =====
+			c.cs.Store(clusterID, remoteCluster)
+			if err := callback(clusterID, remoteCluster); err != nil {
+				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
+				continue
+			}
+			go remoteCluster.Run()
 		}
-		go remoteCluster.Run()
 	}
 
 	log.Infof("Number of remote clusters: %d", c.cs.Len())

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"go.uber.org/atomic"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,7 @@ import (
 const (
 	initialSyncSignal       = "INIT"
 	MultiClusterSecretLabel = "istio/multiCluster"
-	maxRetries              = 5
+	maxRetries              = 100
 )
 
 func init() {
@@ -332,7 +333,9 @@ func (c *Controller) processItem(secretName string) error {
 	}
 
 	if exists {
-		c.addMemberCluster(secretName, obj.(*corev1.Secret))
+		if err := c.addMemberCluster(secretName, obj.(*corev1.Secret)); err != nil {
+			return err
+		}
 	} else {
 		c.deleteMemberCluster(secretName)
 	}
@@ -389,7 +392,8 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, secretName string) (
 	}, nil
 }
 
-func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
+func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) error {
+	errs := &multierror.Error{}
 	for clusterID, kubeConfig := range s.Data {
 		action, callback := "Adding", c.addCallback
 		var oldCluster *Cluster
@@ -399,6 +403,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			if prev.secretName != secretName {
 				log.Errorf("ClusterID reused in two different secrets: %v and %v. ClusterID "+
 					"must be unique across all secrets", prev.secretName, secretName)
+				errs = multierror.Append(errs, fmt.Errorf("ClusterID reused in two different secrets: %v and %v", prev.secretName, secretName))
 				continue
 			}
 			kubeConfigSha := sha256.Sum256(kubeConfig)
@@ -413,6 +418,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 		remoteCluster, err := c.createRemoteCluster(kubeConfig, secretName)
 		if err != nil {
 			log.Errorf("%s cluster_id=%v from secret=%v: %v", action, clusterID, secretName, err)
+			errs = multierror.Append(errs, fmt.Errorf("%s cluster_id=%v from secret=%v: %v", action, clusterID, secretName, err))
 			continue
 		}
 
@@ -456,6 +462,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			if !synced {
 				log.Errorf("New cluster %v failed to sync within %v, skipping update", clusterID, updateSyncTimeout)
 				close(remoteCluster.Stop) // Clean up new cluster resources to prevent goroutine leak
+				errs = multierror.Append(errs, fmt.Errorf("new cluster %v failed to sync within %v", clusterID, updateSyncTimeout))
 				continue
 			}
 			log.Infof("New cluster %v synced, proceeding with replacement", clusterID)
@@ -464,6 +471,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			if err := callback(clusterID, remoteCluster); err != nil {
 				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
 				close(remoteCluster.Stop) // Callback failed, clean up new cluster resources
+				errs = multierror.Append(errs, fmt.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err))
 				continue
 			}
 			c.cs.Store(clusterID, remoteCluster)
@@ -476,6 +484,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			if err := callback(clusterID, remoteCluster); err != nil {
 				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
 				close(remoteCluster.Stop)
+				errs = multierror.Append(errs, fmt.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err))
 				continue
 			}
 			c.cs.Store(clusterID, remoteCluster)
@@ -484,6 +493,7 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 	}
 
 	log.Infof("Number of remote clusters: %d", c.cs.Len())
+	return errs.ErrorOrNil()
 }
 
 func (c *Controller) deleteMemberCluster(secretName string) {

--- a/pkg/kube/secretcontroller/secretcontroller.go
+++ b/pkg/kube/secretcontroller/secretcontroller.go
@@ -473,11 +473,12 @@ func (c *Controller) addMemberCluster(secretName string, s *corev1.Secret) {
 			close(oldCluster.Stop)
 		} else {
 			// ===== Add scenario: keep original logic =====
-			c.cs.Store(clusterID, remoteCluster)
 			if err := callback(clusterID, remoteCluster); err != nil {
 				log.Errorf("%s cluster_id from secret=%v: %s %v", action, clusterID, secretName, err)
+				close(remoteCluster.Stop)
 				continue
 			}
+			c.cs.Store(clusterID, remoteCluster)
 			go remoteCluster.Run()
 		}
 	}


### PR DESCRIPTION
## Summary

- Remote cluster Secret（kubeconfig）更新时，当前 Break-Before-Make 实现会导致 Envoy 收到空配置造成流量中断
- 采用 Make-Before-Break 策略：先启动新集群 Informer 并等待同步完成（1min 超时），再原子替换旧 registry，实现零中断更新
- 合并 `AddMemberCluster` / `UpdateMemberCluster` 为 `addOrUpdateMemberCluster`，消除代码重复并补全更新场景缺失的 NamespaceController / Webhook / ServiceExport 逻辑

### 主要改动

- **`aggregate/controller.go`**：新增 `ReplaceRegistry` 方法，原子替换 registry 避免空缺期
- **`secretcontroller.go`**：更新场景先启动新集群 Informer 并等待同步完成再替换；修复旧 Cluster Stop channel 未关闭的资源泄漏；`createRemoteCluster` 增加 API Server 探活（fail-fast）
- **`multicluster.go`**：合并 Add/Update 为统一函数，使用 `ReplaceRegistry` 原子替换
- **`secrets/kube/multicluster.go`**：直接替换 map entry 消除短暂空缺窗口

### 中断窗口对比

| 方案 | 中断窗口 |
|------|---------|
| 当前实现（Break-Before-Make） | 秒级~分钟级 |
| 本方案（Make-Before-Break） | **零中断** |

## Test plan

- [x] `go test ./pilot/pkg/serviceregistry/aggregate/...` 全部通过
- [x] `go test ./pkg/kube/secretcontroller/...` 全部通过（验证 Make-Before-Break 流程日志正确）
- [x] `go build` 编译通过
- [ ] 部署到测试环境，修改 remote cluster Secret 的 kubeconfig，观察 Envoy listener/cluster count 不下降
- [ ] 检查日志：`Waiting for new cluster X to sync` → `New cluster X synced` → `Closing old cluster`